### PR TITLE
fix: disable WPA3-Personal transition mode in wpa-psk

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+network-manager (1.42.4-2deepin4) unstable; urgency=medium
+
+  * fix: disable WPA3-Personal transition mode in wpa-psk
+
+ -- HeYuMing <heyuming@uniontech.com>  Mon, 03 Jul 2023 14:21:34 +0800
+
 network-manager (1.42.4-2deepin3) unstable; urgency=medium
 
   * add wpasupplicant depends.

--- a/debian/patches/Fix-Disable-WPA3-Personal-Transition-Mode-in-WPA-PSK.patch
+++ b/debian/patches/Fix-Disable-WPA3-Personal-Transition-Mode-in-WPA-PSK.patch
@@ -1,0 +1,27 @@
+diff --git a/src/core/supplicant/nm-supplicant-config.c b/src/core/supplicant/nm-supplicant-config.c
+index c63a005..6ceb6ad 100644
+--- a/src/core/supplicant/nm-supplicant-config.c
++++ b/src/core/supplicant/nm-supplicant-config.c
+@@ -898,14 +898,14 @@ nm_supplicant_config_add_setting_wireless_security(NMSupplicantConfig
+          * some devices that are not fully compatible with WPA3-Personal
+          * transition mode.
+          */
+-        if (_get_capability(priv, NM_SUPPL_CAP_TYPE_SAE)
+-            && _get_capability(priv, NM_SUPPL_CAP_TYPE_PMF)
+-            && _get_capability(priv, NM_SUPPL_CAP_TYPE_BIP)
+-            && (!is_ap || pmf != NM_SETTING_WIRELESS_SECURITY_PMF_DISABLE)) {
+-            g_string_append(key_mgmt_conf, " SAE");
+-            if (!is_ap && _get_capability(priv, NM_SUPPL_CAP_TYPE_FT))
+-                g_string_append(key_mgmt_conf, " FT-SAE");
+-        }
++        // if (_get_capability(priv, NM_SUPPL_CAP_TYPE_SAE)
++        //     && _get_capability(priv, NM_SUPPL_CAP_TYPE_PMF)
++        //     && _get_capability(priv, NM_SUPPL_CAP_TYPE_BIP)
++        //     && (!is_ap || pmf != NM_SETTING_WIRELESS_SECURITY_PMF_DISABLE)) {
++        //     g_string_append(key_mgmt_conf, " SAE");
++        //     if (!is_ap && _get_capability(priv, NM_SUPPL_CAP_TYPE_FT))
++        //         g_string_append(key_mgmt_conf, " FT-SAE");
++        // }
+ 
+     } else if (nm_streq(key_mgmt, "sae")) {
+         pmf = NM_SETTING_WIRELESS_SECURITY_PMF_REQUIRED;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,3 +3,4 @@ uniontech001_add_sunway_support.patch
 fix-time-exceed-uintmax.patch
 deepin-sae-key.patch
 deepin-fix-NetworkManagerwaitonline-failed.patch
+Fix-Disable-WPA3-Personal-Transition-Mode-in-WPA-PSK.patch


### PR DESCRIPTION
Log: 禁用Wpa3-Personal的过渡模式