### PR TITLE
fix: add supplicant dbus property SAEConfirmMismatch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+network-manager (1.44.2-7deepin5) unstable; urgency=medium
+
+  * add supplicant dbus property SAEConfirmMismatch.
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Thu, 26 Dec 2024 14:08:17 +0800
+
 network-manager (1.44.2-7deepin4) unstable; urgency=medium
 
   * add flags of active connection interface

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -3,7 +3,7 @@ core-add-reason-argument-to-NMActiveConnection-device_sta.patch
 core-propagate-the-user-requested-reason-for-act-request-.patch
 uniontech001_add_sunway_support.patch
 fix-time-exceed-uintmax-2.patch
-deepin-sae-key.patch
 deepin-fix-NetworkManagerwaitonline-failed.patch
 0001-disable-broken-ut.patch
 uniontech002_add_activeconnection_flags.patch
+uniontech-sae-display-wrong-password-hint.patch

--- a/debian/patches/uniontech-sae-display-wrong-password-hint.patch
+++ b/debian/patches/uniontech-sae-display-wrong-password-hint.patch
@@ -1,0 +1,98 @@
+Index: network-manager/src/core/devices/wifi/nm-device-wifi.c
+===================================================================
+--- network-manager.orig/src/core/devices/wifi/nm-device-wifi.c	2024-12-24 11:26:32.039959153 +0800
++++ network-manager/src/core/devices/wifi/nm-device-wifi.c	2024-12-26 13:34:19.551090654 +0800
+@@ -2347,15 +2347,15 @@
+ 
+     g_return_val_if_fail(connection, FALSE);
+ 
+-    /* A bad PSK will cause the supplicant to disconnect during the 4-way handshake */
+-    if (old_state != NM_SUPPLICANT_INTERFACE_STATE_4WAY_HANDSHAKE)
+-        return FALSE;
+-
+     s_wsec = nm_connection_get_setting_wireless_security(connection);
+     if (s_wsec)
+         key_mgmt = nm_setting_wireless_security_get_key_mgmt(s_wsec);
+ 
+     if (g_strcmp0(key_mgmt, "wpa-psk") == 0) {
++        /* A bad PSK will cause the supplicant to disconnect during the 4-way handshake */
++        if (old_state != NM_SUPPLICANT_INTERFACE_STATE_4WAY_HANDSHAKE)
++            return FALSE;
++
+ /* -4 (locally-generated WLAN_REASON_DISASSOC_DUE_TO_INACTIVITY) usually
+          * means the driver missed beacons from the AP.  This usually happens
+          * due to driver bugs or faulty power-save management.  It doesn't
+@@ -2369,6 +2369,15 @@
+         return TRUE;
+     }
+ 
++    if (g_strcmp0 (key_mgmt, "sae") == 0) {
++        NMDeviceWifiPrivate *priv = NM_DEVICE_WIFI_GET_PRIVATE (self);
++        if (nm_supplicant_interface_get_sae_confirm_mismatch (priv->sup_iface)) {
++            nm_supplicant_interface_set_sae_confirm_mismatch(priv->sup_iface, 0);
++            *setting_name = NM_SETTING_WIRELESS_SECURITY_SETTING_NAME;
++            return TRUE;
++        }
++    }
++
+     /* Not a WPA-PSK connection */
+     return FALSE;
+ }
+Index: network-manager/src/core/supplicant/nm-supplicant-interface.c
+===================================================================
+--- network-manager.orig/src/core/supplicant/nm-supplicant-interface.c	2024-12-23 21:22:54.180558476 +0800
++++ network-manager/src/core/supplicant/nm-supplicant-interface.c	2024-12-26 11:37:57.992240229 +0800
+@@ -163,6 +163,7 @@
+ 
+     bool ap_isolate_supported : 1;
+     bool ap_isolate_needs_reset : 1;
++    bool sae_confirm_mismatch : 1;
+ } NMSupplicantInterfacePrivate;
+ 
+ struct _NMSupplicantInterfaceClass {
+@@ -1207,6 +1208,22 @@
+     return NM_SUPPLICANT_INTERFACE_GET_PRIVATE(self)->scanning_cached;
+ }
+ 
++void
++nm_supplicant_interface_set_sae_confirm_mismatch (NMSupplicantInterface *self, gboolean new_sae_confirm_mismatch)
++{
++	NMSupplicantInterfacePrivate *priv = NM_SUPPLICANT_INTERFACE_GET_PRIVATE (self);
++
++	priv->sae_confirm_mismatch = new_sae_confirm_mismatch;
++}
++
++gboolean
++nm_supplicant_interface_get_sae_confirm_mismatch (NMSupplicantInterface *self)
++{
++	g_return_val_if_fail(NM_IS_SUPPLICANT_INTERFACE(self), FALSE);
++
++    return NM_SUPPLICANT_INTERFACE_GET_PRIVATE(self)->sae_confirm_mismatch;
++}
++
+ gint64
+ nm_supplicant_interface_get_last_scan(NMSupplicantInterface *self)
+ {
+@@ -1950,6 +1967,9 @@
+         }
+     }
+ 
++    if (nm_g_variant_lookup (properties, "SAEConfirmMismatch", "b", &v_b))
++		nm_supplicant_interface_set_sae_confirm_mismatch (self, v_b);
++
+     if (nm_g_variant_lookup(properties, "Ifname", "&s", &v_s)) {
+         if (nm_strdup_reset(&priv->ifname, v_s))
+             do_log_driver_info = TRUE;
+Index: network-manager/src/core/supplicant/nm-supplicant-interface.h
+===================================================================
+--- network-manager.orig/src/core/supplicant/nm-supplicant-interface.h	2024-12-23 21:22:54.180558476 +0800
++++ network-manager/src/core/supplicant/nm-supplicant-interface.h	2024-12-26 11:38:17.769112407 +0800
+@@ -196,4 +196,8 @@
+ 
+ void nm_supplicant_interface_set_bridge(NMSupplicantInterface *self, const char *bridge);
+ 
++void nm_supplicant_interface_set_sae_confirm_mismatch (NMSupplicantInterface *self, gboolean new_sae_confirm_mismatch);
++
++gboolean nm_supplicant_interface_get_sae_confirm_mismatch (NMSupplicantInterface *self);
++
+ #endif /* __NM_SUPPLICANT_INTERFACE_H__ */


### PR DESCRIPTION
Log: Better handle the problem of the password box popping up after
     the user enters the wrong password in SAE
pms: Bug-282673