### PR TITLE
fix(dns): fix VPN adapter DNS configuration when no domain is set

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+network-manager (1.44.2-7deepin8) unstable; urgency=medium
+
+  * fix VPN adapter DNS configuration when no domain is set
+
+ -- xinpeng.wang <wangxinpeng@uniontech.com>  Tue, 31 Mar 2026 22:07:11 +0800
+
 network-manager (1.44.2-7deepin7) unstable; urgency=medium
 
   * early request dbus name to improve boot performance.

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,3 +9,4 @@ uniontech002_add_activeconnection_flags.patch
 uniontech-sae-display-wrong-password-hint.patch
 uniontech003-deepin-wifi6.patch
 uniontech-early-request-dbus-name.patch
+uniontech-apapter-no-domain-vpn.patch

--- a/debian/patches/uniontech-apapter-no-domain-vpn.patch
+++ b/debian/patches/uniontech-apapter-no-domain-vpn.patch
@@ -1,0 +1,48 @@
+Index: network-manager/src/core/dns/nm-dns-systemd-resolved.c
+===================================================================
+--- network-manager.orig/src/core/dns/nm-dns-systemd-resolved.c
++++ network-manager/src/core/dns/nm-dns-systemd-resolved.c
+@@ -383,18 +383,26 @@ update_add_ip_config(NMDnsSystemdResolve
+     const char                  *domain;
+     gboolean                     has_config = FALSE;
+     const char *const           *strarr;
++    gboolean                    need_add_default_domain = FALSE;
+ 
+     addr_size = nm_utils_addr_family_to_size(ip_data->addr_family);
+ 
++    strarr = nm_l3_config_data_get_nameservers(ip_data->l3cd, ip_data->addr_family, &n);
++
+     if ((!ip_data->domains.search || !ip_data->domains.search[0])
+         && !ip_data->domains.has_default_route_exclusive && !ip_data->domains.has_default_route) {
+         /* we have no search domain (which systemd-resolved uses to routing the request), but
+          * also the "DefaultRoute" is not set on the interface. This setting has no effect and
+          * gets ignored. */
+-        return FALSE;
++        if (n == 0) {
++            return FALSE;
++        }
++        /* [DEEPIN PATCH]: This link has DNS servers but lacks any routing/search
++         * information. We must ensure a routing domain is added later to
++         * prevent systemd-resolved from ignoring these DNS servers. */
++        need_add_default_domain = TRUE;
+     }
+ 
+-    strarr = nm_l3_config_data_get_nameservers(ip_data->l3cd, ip_data->addr_family, &n);
+     for (i = 0; i < n; i++) {
+         const char *server_name;
+         NMIPAddr    a;
+@@ -442,6 +450,14 @@ update_add_ip_config(NMDnsSystemdResolve
+         }
+     }
+ 
++    /* Supplement a wild-card routing domain (~.) for
++     * links that have DNS but would otherwise be ignored by resolved. */
++    if (has_config && need_add_default_domain) {
++        _LOGD("resolved: link %d has DNS servers but no routing domain, adding '.' as fallback",
++                  ip_data->data->ifindex);
++        g_variant_builder_add(domains, "(sb)", ".", TRUE);
++    }
++
+     return has_config;
+ }
+ 


### PR DESCRIPTION
Fix DNS configuration issue for VPN adapters that have DNS servers but lack routing/search domain information
Add fallback mechanism to supplement wild-card routing domain when systemd-resolved would otherwise ignore DNS servers Ensure proper DNS resolution for VPN connections without domain config

Log: Fixed VPN adapter DNS configuration for domain-less connections

Influence:
1. Test VPN connection DNS resolution when no search domain is configured
2. Verify systemd-resolved properly handles DNS servers from domain-less VPN
3. Test DNS functionality for various VPN adapter configurations
4. Validate logging output for fallback domain addition
5. Test backward compatibility with existing VPN configurations

fix(dns): 修复 VPN 适配器无域名时的 DNS 配置问题

修复 VPN 适配器有 DNS 服务器但缺少路由/搜索域名信息时的 DNS 配置问题
添加回退机制，在 systemd-resolved 可能忽略 DNS 服务器时补充通配符路由域
确保无域名配置的 VPN 连接能够正确进行 DNS 解析

Log: 修复 VPN 适配器无域名配置时的 DNS 功能

Influence:
1. 测试无搜索域名配置时 VPN 连接的 DNS 解析功能
2. 验证 systemd-resolved 正确处理无域名 VPN 的 DNS 服务器
3. 测试各种 VPN 适配器配置下的 DNS 功能
4. 验证回退域名添加的日志输出
5. 测试与现有 VPN 配置的向后兼容性

PMS: BUG-355287