### PR TITLE
fix(dns): ensure VPN adapter DNS routing when no domain is configured

### DIFF
--- a/debian/patches/uniontech-apapter-no-domain-vpn.patch
+++ b/debian/patches/uniontech-apapter-no-domain-vpn.patch
@@ -1,48 +1,15 @@
-Index: network-manager/src/core/dns/nm-dns-systemd-resolved.c
+Index: network-manager/src/core/dns/nm-dns-manager.c
 ===================================================================
---- network-manager.orig/src/core/dns/nm-dns-systemd-resolved.c
-+++ network-manager/src/core/dns/nm-dns-systemd-resolved.c
-@@ -383,18 +383,26 @@ update_add_ip_config(NMDnsSystemdResolve
-     const char                  *domain;
-     gboolean                     has_config = FALSE;
-     const char *const           *strarr;
-+    gboolean                    need_add_default_domain = FALSE;
+--- network-manager.orig/src/core/dns/nm-dns-manager.c
++++ network-manager/src/core/dns/nm-dns-manager.c
+@@ -1715,6 +1715,10 @@ _mgr_configs_data_construct(NMDnsManager
+             has_default_route_explicit || (priority < 0 && has_default_route_auto);
+         ip_data->domains.has_default_route =
+             ip_data->domains.has_default_route_exclusive || has_default_route_auto;
++        if (ip_data->ip_config_type == NM_DNS_IP_CONFIG_TYPE_VPN
++                && !nm_l3_config_data_get_searches(ip_data->l3cd, ip_data->addr_family, &num)
++                && !nm_l3_config_data_get_domains(ip_data->l3cd, ip_data->addr_family, &num))
++            ip_data->domains.has_default_route = TRUE;
  
-     addr_size = nm_utils_addr_family_to_size(ip_data->addr_family);
- 
-+    strarr = nm_l3_config_data_get_nameservers(ip_data->l3cd, ip_data->addr_family, &n);
-+
-     if ((!ip_data->domains.search || !ip_data->domains.search[0])
-         && !ip_data->domains.has_default_route_exclusive && !ip_data->domains.has_default_route) {
-         /* we have no search domain (which systemd-resolved uses to routing the request), but
-          * also the "DefaultRoute" is not set on the interface. This setting has no effect and
-          * gets ignored. */
--        return FALSE;
-+        if (n == 0) {
-+            return FALSE;
-+        }
-+        /* [DEEPIN PATCH]: This link has DNS servers but lacks any routing/search
-+         * information. We must ensure a routing domain is added later to
-+         * prevent systemd-resolved from ignoring these DNS servers. */
-+        need_add_default_domain = TRUE;
-     }
- 
--    strarr = nm_l3_config_data_get_nameservers(ip_data->l3cd, ip_data->addr_family, &n);
-     for (i = 0; i < n; i++) {
-         const char *server_name;
-         NMIPAddr    a;
-@@ -442,6 +450,14 @@ update_add_ip_config(NMDnsSystemdResolve
-         }
-     }
- 
-+    /* Supplement a wild-card routing domain (~.) for
-+     * links that have DNS but would otherwise be ignored by resolved. */
-+    if (has_config && need_add_default_domain) {
-+        _LOGD("resolved: link %d has DNS servers but no routing domain, adding '.' as fallback",
-+                  ip_data->data->ifindex);
-+        g_variant_builder_add(domains, "(sb)", ".", TRUE);
-+    }
-+
-     return has_config;
- }
- 
+         {
+             gs_free char *str1 = NULL;


### PR DESCRIPTION
Fix DNS routing issue for VPN adapters that lack search/domain configuration Set default route flag for VPN connections without search or domain settings Ensure proper DNS resolution for VPN connections with DNS servers but no domains Update debian changelog to reflect the DNS configuration fix

Log: Fixed VPN adapter DNS routing for connections without domain config

Influence:
1. Test VPN connection DNS resolution when no search or domain is configured
2. Verify DNS functionality for VPN adapters with DNS servers but no domains
3. Test backward compatibility with existing VPN configurations
4. Validate DNS routing behavior for various VPN connection scenarios
5. Test system stability with the new default route setting

fix(dns): 确保 VPN 适配器无域名配置时的 DNS 路由功能

修复 VPN 适配器缺少搜索/域名配置时的 DNS 路由问题
为无搜索或域名设置的 VPN 连接设置默认路由标志
确保有 DNS 服务器但无域名的 VPN 连接能够正确进行 DNS 解析
更新 debian changelog 以反映 DNS 配置修复

Log: 修复 VPN 适配器无域名配置时的 DNS 路由功能

Influence:
1. 测试无搜索或域名配置时 VPN 连接的 DNS 解析功能
2. 验证有 DNS 服务器但无域名的 VPN 适配器的 DNS 功能
3. 测试与现有 VPN 配置的向后兼容性
4. 验证各种 VPN 连接场景下的 DNS 路由行为
5. 测试新默认路由设置的系统稳定性

PMS: BUG-355287