### PR TITLE
fix(wifi/hotspot): retry with different frequency on AP mode timeout

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+network-manager (1.44.2-7deepin9) unstable; urgency=medium
+
+  * fix(wifi/hotspot): retry with different frequency on AP mode timeout
+
+ -- donghualin <donghualin@uniontech.com>  Tue, 09 Jun 2026 09:47:58 +0800
+
 network-manager (1.44.2-7deepin8) unstable; urgency=medium
 
   * feat: add autoconnect-reset-retries configuration

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -11,3 +11,4 @@ uniontech003-deepin-wifi6.patch
 uniontech-early-request-dbus-name.patch
 uniontech004-add-autoresetretry-config.patch
 uniontech005-hotspot-retry-when-failure.patch
+uniontech004-update-unittest.patch

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -10,3 +10,4 @@ uniontech-sae-display-wrong-password-hint.patch
 uniontech003-deepin-wifi6.patch
 uniontech-early-request-dbus-name.patch
 uniontech004-add-autoresetretry-config.patch
+uniontech005-hotspot-retry-when-failure.patch

--- a/debian/patches/uniontech004-update-unittest.patch
+++ b/debian/patches/uniontech004-update-unittest.patch
@@ -1,0 +1,2587 @@
+Index: network-manager/src/libnm-client-impl/libnm.ver
+===================================================================
+--- network-manager.orig/src/libnm-client-impl/libnm.ver
++++ network-manager/src/libnm-client-impl/libnm.ver
+@@ -1122,6 +1122,7 @@ global:
+ 	nm_dns_entry_get_vpn;
+ 	nm_dns_entry_unref;
+ 	nm_setting_connection_get_autoconnect_retries;
++	nm_setting_connection_get_autoconnect_reset_retries;
+ 	nm_setting_macsec_get_encrypt;
+ 	nm_setting_macsec_get_mka_cak;
+ 	nm_setting_macsec_get_mka_cak_flags;
+Index: network-manager/src/libnm-core-impl/gen-metadata-nm-settings-libnm-core.xml.in
+===================================================================
+--- network-manager.orig/src/libnm-core-impl/gen-metadata-nm-settings-libnm-core.xml.in
++++ network-manager/src/libnm-core-impl/gen-metadata-nm-settings-libnm-core.xml.in
+@@ -771,11 +771,11 @@
+                   dbus-type="i"
+                   gprop-type="gint"
+                   />
+-        <property name="autoconnect-retries"
++        <property name="autoconnect-reset-retries"
+                   dbus-type="i"
+                   gprop-type="gint"
+                   />
+-        <property name="autoconnect-reset-retries"
++        <property name="autoconnect-retries"
+                   dbus-type="i"
+                   gprop-type="gint"
+                   />
+Index: network-manager/src/libnm-core-impl/nm-setting-connection.c
+===================================================================
+--- network-manager.orig/src/libnm-core-impl/nm-setting-connection.c
++++ network-manager/src/libnm-core-impl/nm-setting-connection.c
+@@ -587,6 +587,8 @@ nm_setting_connection_get_autoconnect_re
+  * 1 means to reset after a timeout and try again.
+  *
+  * Returns: the autoconnect-reset-retries value (-1, 0, or 1)
++ *
++ * Since: 1.6
+  **/
+ int
+ nm_setting_connection_get_autoconnect_reset_retries(NMSettingConnection *setting)
+@@ -2170,13 +2172,11 @@ nm_setting_connection_class_init(NMSetti
+     /**
+      * NMSettingConnection:autoconnect-reset-retries:
+      *
+-     * Controls whether the connection should be automatically retried after
+-     * the autoconnect retry count is exhausted. %TRUE means the connection
+-     * will be blocked for a period and then the retry count is reset so the
+-     * connection can be attempted again automatically. %FALSE means once the
+-     * connection fails the configured number of times, it will not be retried
+-     * automatically. The value -1 means to use the global default setting
+-     * from NetworkManager.conf.
++     * Controls whether the autoconnect retry count is reset after being
++     * exhausted. -1 means to use the global default from
++     * NetworkManager.conf (which defaults to true), 0 means not to reset (no
++     * more autoconnect attempts after retries are exhausted), 1 means to
++     * reset after a timeout and try autoconnecting again.
+      **/
+     /* ---ifcfg-rh---
+      * property: autoconnect-reset-retries
+@@ -2187,6 +2187,17 @@ nm_setting_connection_class_init(NMSetti
+      * example: AUTOCONNECT_RESET_RETRIES=-1
+      * ---end---
+      */
++    /* ---nmcli---
++     * property: autoconnect-reset-retries
++     * description: Controls whether the connection should be automatically retried after
++     *   the autoconnect retry count is exhausted. TRUE means the connection
++     *   will be blocked for a period and then the retry count is reset so the
++     *   connection can be attempted again automatically. FALSE means once the
++     *   connection fails the configured number of times, it will not be retried
++     *   automatically. The value -1 means to use the global default setting
++     *   from NetworkManager.conf.
++     * ---end---
++     */
+     _nm_setting_property_define_direct_int32(properties_override,
+                                              obj_properties,
+                                              NM_SETTING_CONNECTION_AUTOCONNECT_RESET_RETRIES,
+Index: network-manager/src/libnm-core-impl/tests/test-general.c
+===================================================================
+--- network-manager.orig/src/libnm-core-impl/tests/test-general.c
++++ network-manager/src/libnm-core-impl/tests/test-general.c
+@@ -3998,6 +3998,7 @@ test_connection_diff_a_only(void)
+           {NM_SETTING_CONNECTION_AUTOCONNECT, NM_SETTING_DIFF_RESULT_IN_A},
+           {NM_SETTING_CONNECTION_AUTOCONNECT_PRIORITY, NM_SETTING_DIFF_RESULT_IN_A},
+           {NM_SETTING_CONNECTION_AUTOCONNECT_RETRIES, NM_SETTING_DIFF_RESULT_IN_A},
++          {NM_SETTING_CONNECTION_AUTOCONNECT_RESET_RETRIES, NM_SETTING_DIFF_RESULT_IN_A},
+           {NM_SETTING_CONNECTION_MULTI_CONNECT, NM_SETTING_DIFF_RESULT_IN_A},
+           {NM_SETTING_CONNECTION_READ_ONLY, NM_SETTING_DIFF_RESULT_IN_A},
+           {NM_SETTING_CONNECTION_PERMISSIONS, NM_SETTING_DIFF_RESULT_IN_A},
+Index: network-manager/src/libnm-core-public/nm-setting-connection.h
+===================================================================
+--- network-manager.orig/src/libnm-core-public/nm-setting-connection.h
++++ network-manager/src/libnm-core-public/nm-setting-connection.h
+@@ -168,6 +168,7 @@ gboolean    nm_setting_connection_get_au
+ int         nm_setting_connection_get_autoconnect_priority(NMSettingConnection *setting);
+ NM_AVAILABLE_IN_1_6
+ int nm_setting_connection_get_autoconnect_retries(NMSettingConnection *setting);
++NM_AVAILABLE_IN_1_6
+ int nm_setting_connection_get_autoconnect_reset_retries(NMSettingConnection *setting);
+ NM_AVAILABLE_IN_1_14
+ NMConnectionMultiConnect nm_setting_connection_get_multi_connect(NMSettingConnection *setting);
+Index: network-manager/src/libnmc-setting/settings-docs.h.in
+===================================================================
+--- network-manager.orig/src/libnmc-setting/settings-docs.h.in
++++ network-manager/src/libnmc-setting/settings-docs.h.in
+@@ -3,8 +3,8 @@
+ #define DESCRIBE_DOC_NM_SETTING_CONNECTION_AUTH_RETRIES N_("The number of retries for the authentication. Zero means to try indefinitely; -1 means to use a global default. If the global default is not set, the authentication retries for 3 times before failing the connection. Currently, this only applies to 802-1x authentication.")
+ #define DESCRIBE_DOC_NM_SETTING_CONNECTION_AUTOCONNECT N_("Whether or not the connection should be automatically connected by NetworkManager when the resources for the connection are available. TRUE to automatically activate the connection, FALSE to require manual intervention to activate the connection. Autoconnect happens when the circumstances are suitable. That means for example that the device is currently managed and not active. Autoconnect thus never replaces or competes with an already active profile. Note that autoconnect is not implemented for VPN profiles. See \"secondaries\" as an alternative to automatically connect VPN profiles. If multiple profiles are ready to autoconnect on the same device, the one with the better \"connection.autoconnect-priority\" is chosen. If the priorities are equal, then the most recently connected profile is activated. If the profiles were not connected earlier or their \"connection.timestamp\" is identical, the choice is undefined. Depending on \"connection.multi-connect\", a profile can (auto)connect only once at a time or multiple times.")
+ #define DESCRIBE_DOC_NM_SETTING_CONNECTION_AUTOCONNECT_PRIORITY N_("The autoconnect priority in range -999 to 999. If the connection is set to autoconnect, connections with higher priority will be preferred. The higher number means higher priority. Defaults to 0. Note that this property only matters if there are more than one candidate profile to select for autoconnect. In case of equal priority, the profile used most recently is chosen.")
++#define DESCRIBE_DOC_NM_SETTING_CONNECTION_AUTOCONNECT_RESET_RETRIES N_("Controls whether the connection should be automatically retried after the autoconnect retry count is exhausted. TRUE means the connection will be blocked for a period and then the retry count is reset so the connection can be attempted again automatically. FALSE means once the connection fails the configured number of times, it will not be retried automatically. The value -1 means to use the global default setting from NetworkManager.conf.")
+ #define DESCRIBE_DOC_NM_SETTING_CONNECTION_AUTOCONNECT_RETRIES N_("The number of times a connection should be tried when autoactivating before giving up. Zero means forever, -1 means the global default (4 times if not overridden). Setting this to 1 means to try activation only once before blocking autoconnect. Note that after a timeout, NetworkManager will try to autoconnect again.")
+-#define DESCRIBE_DOC_NM_SETTING_CONNECTION_AUTOCONNECT_RESET_RETRIES N_("Controls whether the autoconnect retry count is reset after being exhausted. -1 means to use the global default from NetworkManager.conf (which defaults to true), 0 means not to reset (no more autoconnect attempts after retries are exhausted), 1 means to reset after a timeout and try autoconnecting again.")
+ #define DESCRIBE_DOC_NM_SETTING_CONNECTION_AUTOCONNECT_SLAVES N_("Whether or not slaves of this connection should be automatically brought up when NetworkManager activates this connection. This only has a real effect for master connections. The properties \"autoconnect\", \"autoconnect-priority\" and \"autoconnect-retries\" are unrelated to this setting. The permitted values are: 0: leave slave connections untouched, 1: activate all the slave connections with this connection, -1: default. If -1 (default) is set, global connection.autoconnect-slaves is read to determine the real value. If it is default as well, this fallbacks to 0.")
+ #define DESCRIBE_DOC_NM_SETTING_CONNECTION_DNS_OVER_TLS N_("Whether DNSOverTls (dns-over-tls) is enabled for the connection. DNSOverTls is a technology which uses TLS to encrypt dns traffic. The permitted values are: \"yes\" (2) use DNSOverTls and disabled fallback, \"opportunistic\" (1) use DNSOverTls but allow fallback to unencrypted resolution, \"no\" (0) don't ever use DNSOverTls. If unspecified \"default\" depends on the plugin used. Systemd-resolved uses global setting. This feature requires a plugin which supports DNSOverTls. Otherwise, the setting has no effect. One such plugin is dns-systemd-resolved.")
+ #define DESCRIBE_DOC_NM_SETTING_CONNECTION_GATEWAY_PING_TIMEOUT N_("If greater than zero, delay success of IP addressing until either the timeout is reached, or an IP gateway replies to a ping.")
+Index: network-manager/src/nmcli/gen-metadata-nm-settings-nmcli.xml.in
+===================================================================
+--- network-manager.orig/src/nmcli/gen-metadata-nm-settings-nmcli.xml.in
++++ network-manager/src/nmcli/gen-metadata-nm-settings-nmcli.xml.in
+@@ -385,7 +385,7 @@
+         <property name="autoconnect-retries"
+                   nmcli-description="The number of times a connection should be tried when autoactivating before giving up. Zero means forever, -1 means the global default (4 times if not overridden). Setting this to 1 means to try activation only once before blocking autoconnect. Note that after a timeout, NetworkManager will try to autoconnect again." />
+         <property name="autoconnect-reset-retries"
+-                  nmcli-description="Controls whether the autoconnect retry count is reset after being exhausted. -1 means to use the global default from NetworkManager.conf (which defaults to true), 0 means not to reset (no more autoconnect attempts after retries are exhausted), 1 means to reset after a timeout and try autoconnecting again." />
++                  nmcli-description="Controls whether the connection should be automatically retried after the autoconnect retry count is exhausted. TRUE means the connection will be blocked for a period and then the retry count is reset so the connection can be attempted again automatically. FALSE means once the connection fails the configured number of times, it will not be retried automatically. The value -1 means to use the global default setting from NetworkManager.conf." />
+         <property name="multi-connect"
+                   nmcli-description="Specifies whether the profile can be active multiple times at a particular moment. The value is of type NMConnectionMultiConnect." />
+         <property name="auth-retries"
+Index: network-manager/src/tests/client/test-client.check-on-disk/test_002.expected
+===================================================================
+--- network-manager.orig/src/tests/client/test-client.check-on-disk/test_002.expected
++++ network-manager/src/tests/client/test-client.check-on-disk/test_002.expected
+@@ -502,7 +502,7 @@ NAME   UUID
+ con-1  5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  --     
+ 
+ <<<
+-size: 1373
++size: 1426
+ location: src/tests/client/test-client.py:test_002()/23
+ cmd: $NMCLI c s con-1
+ lang: C
+@@ -517,6 +517,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -537,7 +538,7 @@ connection.wait-device-timeout:
+ connection.wait-activation-delay:       -1
+ 
+ <<<
+-size: 1384
++size: 1437
+ location: src/tests/client/test-client.py:test_002()/24
+ cmd: $NMCLI c s con-1
+ lang: pl_PL.UTF-8
+@@ -552,6 +553,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+Index: network-manager/src/tests/client/test-client.check-on-disk/test_003.expected
+===================================================================
+--- network-manager.orig/src/tests/client/test-client.check-on-disk/test_003.expected
++++ network-manager/src/tests/client/test-client.check-on-disk/test_003.expected
+@@ -182,7 +182,7 @@ id
+ path
+ uuid
+ <<<
+-size: 5182
++size: 5235
+ location: src/tests/client/test-client.py:test_003()/14
+ cmd: $NMCLI con s con-gsm1
+ lang: C
+@@ -197,6 +197,7 @@ connection.interface-name:
+ connection.autoconnect:                 no
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -301,7 +302,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 5220
++size: 5273
+ location: src/tests/client/test-client.py:test_003()/15
+ cmd: $NMCLI con s con-gsm1
+ lang: pl_PL.UTF-8
+@@ -316,6 +317,7 @@ connection.interface-name:
+ connection.autoconnect:                 nie
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -450,7 +452,7 @@ gsm:no:::<hidden>:0:xyz.con-gsm1::<hidde
+ proxy:none:no::
+ 
+ <<<
+-size: 5170
++size: 5223
+ location: src/tests/client/test-client.py:test_003()/18
+ cmd: $NMCLI con s con-gsm2
+ lang: C
+@@ -465,6 +467,7 @@ connection.interface-name:
+ connection.autoconnect:                 no
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -569,7 +572,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 5208
++size: 5261
+ location: src/tests/client/test-client.py:test_003()/19
+ cmd: $NMCLI con s con-gsm2
+ lang: pl_PL.UTF-8
+@@ -584,6 +587,7 @@ connection.interface-name:
+ connection.autoconnect:                 nie
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -718,7 +722,7 @@ gsm:no:::<hidden>:0:::<hidden>:0:no::::a
+ proxy:none:no::
+ 
+ <<<
+-size: 5170
++size: 5223
+ location: src/tests/client/test-client.py:test_003()/22
+ cmd: $NMCLI con s con-gsm3
+ lang: C
+@@ -733,6 +737,7 @@ connection.interface-name:
+ connection.autoconnect:                 no
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -837,7 +842,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 5208
++size: 5261
+ location: src/tests/client/test-client.py:test_003()/23
+ cmd: $NMCLI con s con-gsm3
+ lang: pl_PL.UTF-8
+@@ -852,6 +857,7 @@ connection.interface-name:
+ connection.autoconnect:                 nie
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -1126,7 +1132,7 @@ UUID                                  NA
+ UUID-ethernet-REPLACED-REPLACED-REPL  ethernet 
+ 
+ <<<
+-size: 4922
++size: 4975
+ location: src/tests/client/test-client.py:test_003()/37
+ cmd: $NMCLI -f ALL con s ethernet
+ lang: C
+@@ -1141,6 +1147,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -1239,7 +1246,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 4957
++size: 5010
+ location: src/tests/client/test-client.py:test_003()/38
+ cmd: $NMCLI -f ALL con s ethernet
+ lang: pl_PL.UTF-8
+@@ -1254,6 +1261,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -1372,7 +1380,7 @@ stdout: 51 bytes
+ GENERAL.STATE:                          aktywowano
+ 
+ <<<
+-size: 5624
++size: 5677
+ location: src/tests/client/test-client.py:test_003()/41
+ cmd: $NMCLI con s ethernet
+ lang: C
+@@ -1387,6 +1395,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -1498,7 +1507,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 5663
++size: 5716
+ location: src/tests/client/test-client.py:test_003()/42
+ cmd: $NMCLI con s ethernet
+ lang: pl_PL.UTF-8
+@@ -1513,6 +1522,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -2110,7 +2120,7 @@ UUID                                  NA
+ UUID-ethernet-REPLACED-REPLACED-REPL  ethernet 
+ 
+ <<<
+-size: 4922
++size: 4975
+ location: src/tests/client/test-client.py:test_003()/62
+ cmd: $NMCLI -f ALL con s ethernet
+ lang: C
+@@ -2125,6 +2135,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -2223,7 +2234,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 4957
++size: 5010
+ location: src/tests/client/test-client.py:test_003()/63
+ cmd: $NMCLI -f ALL con s ethernet
+ lang: pl_PL.UTF-8
+@@ -2238,6 +2249,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -2360,7 +2372,7 @@ GENERAL.STATE:
+ GENERAL.STATE:                          aktywowano
+ 
+ <<<
+-size: 6334
++size: 6387
+ location: src/tests/client/test-client.py:test_003()/66
+ cmd: $NMCLI con s ethernet
+ lang: C
+@@ -2375,6 +2387,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -2500,7 +2513,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 6377
++size: 6430
+ location: src/tests/client/test-client.py:test_003()/67
+ cmd: $NMCLI con s ethernet
+ lang: pl_PL.UTF-8
+@@ -2515,6 +2528,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -3118,7 +3132,7 @@ UUID-con-gsm3-REPLACED-REPLACED-REPL  gs
+ UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet 
+ 
+ <<<
+-size: 6337
++size: 6390
+ location: src/tests/client/test-client.py:test_003()/82
+ cmd: $NMCLI con s ethernet
+ lang: C
+@@ -3133,6 +3147,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -3258,7 +3273,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 6381
++size: 6434
+ location: src/tests/client/test-client.py:test_003()/83
+ cmd: $NMCLI con s ethernet
+ lang: pl_PL.UTF-8
+@@ -3273,6 +3288,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -3398,7 +3414,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 5667
++size: 5720
+ location: src/tests/client/test-client.py:test_003()/84
+ cmd: $NMCLI c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -3413,6 +3429,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -3524,7 +3541,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 5707
++size: 5760
+ location: src/tests/client/test-client.py:test_003()/85
+ cmd: $NMCLI c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -3539,6 +3556,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -3860,7 +3878,7 @@ UUID-con-gsm3-REPLACED-REPLACED-REPL  gs
+ UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet 
+ 
+ <<<
+-size: 6349
++size: 6402
+ location: src/tests/client/test-client.py:test_003()/92
+ cmd: $NMCLI --color yes con s ethernet
+ lang: C
+@@ -3875,6 +3893,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4000,7 +4019,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 6393
++size: 6446
+ location: src/tests/client/test-client.py:test_003()/93
+ cmd: $NMCLI --color yes con s ethernet
+ lang: pl_PL.UTF-8
+@@ -4015,6 +4034,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4140,7 +4160,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 5679
++size: 5732
+ location: src/tests/client/test-client.py:test_003()/94
+ cmd: $NMCLI --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -4155,6 +4175,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4266,7 +4287,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 5719
++size: 5772
+ location: src/tests/client/test-client.py:test_003()/95
+ cmd: $NMCLI --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -4281,6 +4302,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4618,7 +4640,7 @@ UUID-con-gsm3-REPLACED-REPLACED-REPL  gs
+ UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet 
+ 
+ <<<
+-size: 7590
++size: 7643
+ location: src/tests/client/test-client.py:test_003()/102
+ cmd: $NMCLI --pretty con s ethernet
+ lang: C
+@@ -4636,6 +4658,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4774,7 +4797,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 7655
++size: 7708
+ location: src/tests/client/test-client.py:test_003()/103
+ cmd: $NMCLI --pretty con s ethernet
+ lang: pl_PL.UTF-8
+@@ -4792,6 +4815,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4930,7 +4954,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6608
++size: 6661
+ location: src/tests/client/test-client.py:test_003()/104
+ cmd: $NMCLI --pretty c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -4948,6 +4972,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -5068,7 +5093,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6661
++size: 6714
+ location: src/tests/client/test-client.py:test_003()/105
+ cmd: $NMCLI --pretty c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -5086,6 +5111,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -5456,7 +5482,7 @@ UUID-con-gsm3-REPLACED-REPLACED-REPL  gs
+ UUID-con-xx1-REPLACED-REPLACED-REPLA  ethernet 
+ 
+ <<<
+-size: 7602
++size: 7655
+ location: src/tests/client/test-client.py:test_003()/112
+ cmd: $NMCLI --pretty --color yes con s ethernet
+ lang: C
+@@ -5474,6 +5500,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -5612,7 +5639,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 7667
++size: 7720
+ location: src/tests/client/test-client.py:test_003()/113
+ cmd: $NMCLI --pretty --color yes con s ethernet
+ lang: pl_PL.UTF-8
+@@ -5630,6 +5657,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -5768,7 +5796,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6620
++size: 6673
+ location: src/tests/client/test-client.py:test_003()/114
+ cmd: $NMCLI --pretty --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -5786,6 +5814,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -5906,7 +5935,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6673
++size: 6726
+ location: src/tests/client/test-client.py:test_003()/115
+ cmd: $NMCLI --pretty --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -5924,6 +5953,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -6274,7 +6304,7 @@ UUID-con-gsm3-REPLACED-REPLACED-REPL:gsm
+ UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet
+ 
+ <<<
+-size: 3382
++size: 3435
+ location: src/tests/client/test-client.py:test_003()/122
+ cmd: $NMCLI --terse con s ethernet
+ lang: C
+@@ -6289,6 +6319,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -6414,7 +6445,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3392
++size: 3445
+ location: src/tests/client/test-client.py:test_003()/123
+ cmd: $NMCLI --terse con s ethernet
+ lang: pl_PL.UTF-8
+@@ -6429,6 +6460,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -6554,7 +6586,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3032
++size: 3085
+ location: src/tests/client/test-client.py:test_003()/124
+ cmd: $NMCLI --terse c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -6569,6 +6601,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -6680,7 +6713,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3042
++size: 3095
+ location: src/tests/client/test-client.py:test_003()/125
+ cmd: $NMCLI --terse c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -6695,6 +6728,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -7012,7 +7046,7 @@ UUID-con-gsm3-REPLACED-REPLACED-REPL:gsm
+ UUID-con-xx1-REPLACED-REPLACED-REPLA:802-3-ethernet
+ 
+ <<<
+-size: 3394
++size: 3447
+ location: src/tests/client/test-client.py:test_003()/132
+ cmd: $NMCLI --terse --color yes con s ethernet
+ lang: C
+@@ -7027,6 +7061,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -7152,7 +7187,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3404
++size: 3457
+ location: src/tests/client/test-client.py:test_003()/133
+ cmd: $NMCLI --terse --color yes con s ethernet
+ lang: pl_PL.UTF-8
+@@ -7167,6 +7202,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -7292,7 +7328,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3044
++size: 3097
+ location: src/tests/client/test-client.py:test_003()/134
+ cmd: $NMCLI --terse --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -7307,6 +7343,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -7418,7 +7455,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3054
++size: 3107
+ location: src/tests/client/test-client.py:test_003()/135
+ cmd: $NMCLI --terse --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -7433,6 +7470,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -9482,7 +9520,7 @@ UUID:
+ TYPE:                                   ethernet
+ 
+ <<<
+-size: 6355
++size: 6408
+ location: src/tests/client/test-client.py:test_003()/202
+ cmd: $NMCLI --mode multiline con s ethernet
+ lang: C
+@@ -9497,6 +9535,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -9622,7 +9661,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 6399
++size: 6452
+ location: src/tests/client/test-client.py:test_003()/203
+ cmd: $NMCLI --mode multiline con s ethernet
+ lang: pl_PL.UTF-8
+@@ -9637,6 +9676,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -9762,7 +9802,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 5685
++size: 5738
+ location: src/tests/client/test-client.py:test_003()/204
+ cmd: $NMCLI --mode multiline c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -9777,6 +9817,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -9888,7 +9929,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 5725
++size: 5778
+ location: src/tests/client/test-client.py:test_003()/205
+ cmd: $NMCLI --mode multiline c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -9903,6 +9944,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -10428,7 +10470,7 @@ UUID:
+ TYPE:                                   ethernet
+ 
+ <<<
+-size: 6367
++size: 6420
+ location: src/tests/client/test-client.py:test_003()/212
+ cmd: $NMCLI --mode multiline --color yes con s ethernet
+ lang: C
+@@ -10443,6 +10485,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -10568,7 +10611,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 6411
++size: 6464
+ location: src/tests/client/test-client.py:test_003()/213
+ cmd: $NMCLI --mode multiline --color yes con s ethernet
+ lang: pl_PL.UTF-8
+@@ -10583,6 +10626,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -10708,7 +10752,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 5697
++size: 5750
+ location: src/tests/client/test-client.py:test_003()/214
+ cmd: $NMCLI --mode multiline --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -10723,6 +10767,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -10834,7 +10879,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:                    --
+ 
+ <<<
+-size: 5737
++size: 5790
+ location: src/tests/client/test-client.py:test_003()/215
+ cmd: $NMCLI --mode multiline --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -10849,6 +10894,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -11412,7 +11458,7 @@ TYPE:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 7607
++size: 7660
+ location: src/tests/client/test-client.py:test_003()/222
+ cmd: $NMCLI --mode multiline --pretty con s ethernet
+ lang: C
+@@ -11430,6 +11476,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -11568,7 +11615,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 7672
++size: 7725
+ location: src/tests/client/test-client.py:test_003()/223
+ cmd: $NMCLI --mode multiline --pretty con s ethernet
+ lang: pl_PL.UTF-8
+@@ -11586,6 +11633,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -11724,7 +11772,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6625
++size: 6678
+ location: src/tests/client/test-client.py:test_003()/224
+ cmd: $NMCLI --mode multiline --pretty c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -11742,6 +11790,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -11862,7 +11911,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6678
++size: 6731
+ location: src/tests/client/test-client.py:test_003()/225
+ cmd: $NMCLI --mode multiline --pretty c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -11880,6 +11929,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -12476,7 +12526,7 @@ TYPE:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 7619
++size: 7672
+ location: src/tests/client/test-client.py:test_003()/232
+ cmd: $NMCLI --mode multiline --pretty --color yes con s ethernet
+ lang: C
+@@ -12494,6 +12544,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -12632,7 +12683,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 7684
++size: 7737
+ location: src/tests/client/test-client.py:test_003()/233
+ cmd: $NMCLI --mode multiline --pretty --color yes con s ethernet
+ lang: pl_PL.UTF-8
+@@ -12650,6 +12701,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -12788,7 +12840,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6637
++size: 6690
+ location: src/tests/client/test-client.py:test_003()/234
+ cmd: $NMCLI --mode multiline --pretty --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -12806,6 +12858,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -12926,7 +12979,7 @@ GENERAL.MASTER-PATH:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6690
++size: 6743
+ location: src/tests/client/test-client.py:test_003()/235
+ cmd: $NMCLI --mode multiline --pretty --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -12944,6 +12997,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -13502,7 +13556,7 @@ UUID:UUID-con-xx1-REPLACED-REPLACED-REPL
+ TYPE:802-3-ethernet
+ 
+ <<<
+-size: 3399
++size: 3452
+ location: src/tests/client/test-client.py:test_003()/242
+ cmd: $NMCLI --mode multiline --terse con s ethernet
+ lang: C
+@@ -13517,6 +13571,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -13642,7 +13697,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3409
++size: 3462
+ location: src/tests/client/test-client.py:test_003()/243
+ cmd: $NMCLI --mode multiline --terse con s ethernet
+ lang: pl_PL.UTF-8
+@@ -13657,6 +13712,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -13782,7 +13838,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3049
++size: 3102
+ location: src/tests/client/test-client.py:test_003()/244
+ cmd: $NMCLI --mode multiline --terse c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -13797,6 +13853,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -13908,7 +13965,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3059
++size: 3112
+ location: src/tests/client/test-client.py:test_003()/245
+ cmd: $NMCLI --mode multiline --terse c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -13923,6 +13980,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -14448,7 +14506,7 @@ UUID:UUID-con-xx1-REPLACED-REPLACED-REPL
+ TYPE:802-3-ethernet
+ 
+ <<<
+-size: 3411
++size: 3464
+ location: src/tests/client/test-client.py:test_003()/252
+ cmd: $NMCLI --mode multiline --terse --color yes con s ethernet
+ lang: C
+@@ -14463,6 +14521,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -14588,7 +14647,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3421
++size: 3474
+ location: src/tests/client/test-client.py:test_003()/253
+ cmd: $NMCLI --mode multiline --terse --color yes con s ethernet
+ lang: pl_PL.UTF-8
+@@ -14603,6 +14662,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -14728,7 +14788,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3061
++size: 3114
+ location: src/tests/client/test-client.py:test_003()/254
+ cmd: $NMCLI --mode multiline --terse --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: C
+@@ -14743,6 +14803,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -14854,7 +14915,7 @@ GENERAL.ZONE:
+ GENERAL.MASTER-PATH:
+ 
+ <<<
+-size: 3071
++size: 3124
+ location: src/tests/client/test-client.py:test_003()/255
+ cmd: $NMCLI --mode multiline --terse --color yes c s /org/freedesktop/NetworkManager/ActiveConnection/1
+ lang: pl_PL.UTF-8
+@@ -14869,6 +14930,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+Index: network-manager/src/tests/client/test-client.check-on-disk/test_004.expected
+===================================================================
+--- network-manager.orig/src/tests/client/test-client.check-on-disk/test_004.expected
++++ network-manager/src/tests/client/test-client.check-on-disk/test_004.expected
+@@ -58,7 +58,7 @@ location: src/tests/client/test-client.p
+ cmd: $NMCLI connection mod con-xx1 ipv4.addresses 192.168.77.5/24 ipv4.routes '2.3.4.5/32 192.168.77.1' ipv6.addresses 1:2:3:4::6/64 ipv6.routes 1:2:3:4:5:6::5/128
+ lang: C
+ returncode: 0
+-size: 5080
++size: 5133
+ location: src/tests/client/test-client.py:test_004()/8
+ cmd: $NMCLI con s con-xx1
+ lang: C
+@@ -73,6 +73,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -172,7 +173,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 5115
++size: 5168
+ location: src/tests/client/test-client.py:test_004()/9
+ cmd: $NMCLI con s con-xx1
+ lang: pl_PL.UTF-8
+@@ -187,6 +188,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -322,7 +324,7 @@ con-vpn-1  UUID-con-vpn-1-REPLACED-REPLA
+ con-xx1    UUID-con-xx1-REPLACED-REPLACED-REPLA  wifi      --     
+ 
+ <<<
+-size: 4578
++size: 4631
+ location: src/tests/client/test-client.py:test_004()/13
+ cmd: $NMCLI con s con-vpn-1
+ lang: C
+@@ -337,6 +339,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -426,7 +429,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 4605
++size: 4658
+ location: src/tests/client/test-client.py:test_004()/14
+ cmd: $NMCLI con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -441,6 +444,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -602,7 +606,7 @@ con-xx1    UUID-con-xx1-REPLACED-REPLACE
+ con-1      5fcfd6d7-1e63-3332-8826-a7eda103792d  ethernet  --     
+ 
+ <<<
+-size: 5706
++size: 5759
+ location: src/tests/client/test-client.py:test_004()/21
+ cmd: $NMCLI con s con-vpn-1
+ lang: C
+@@ -617,6 +621,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -727,7 +732,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5739
++size: 5792
+ location: src/tests/client/test-client.py:test_004()/22
+ cmd: $NMCLI con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -742,6 +747,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -934,7 +940,7 @@ Strony podręcznika nmcli(1) i nmcli-ex
+ o użyciu.
+ 
+ <<<
+-size: 5712
++size: 5765
+ location: src/tests/client/test-client.py:test_004()/25
+ cmd: $NMCLI con s con-vpn-1
+ lang: C
+@@ -949,6 +955,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -1059,7 +1066,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5749
++size: 5802
+ location: src/tests/client/test-client.py:test_004()/26
+ cmd: $NMCLI con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -1074,6 +1081,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -1184,7 +1192,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5712
++size: 5765
+ location: src/tests/client/test-client.py:test_004()/27
+ cmd: $NMCLI con s con-vpn-1
+ lang: C
+@@ -1199,6 +1207,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -1309,7 +1318,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5749
++size: 5802
+ location: src/tests/client/test-client.py:test_004()/28
+ cmd: $NMCLI con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -1324,6 +1333,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -1434,7 +1444,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 4585
++size: 4638
+ location: src/tests/client/test-client.py:test_004()/29
+ cmd: $NMCLI -f ALL con s con-vpn-1
+ lang: C
+@@ -1449,6 +1459,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -1538,7 +1549,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 4612
++size: 4665
+ location: src/tests/client/test-client.py:test_004()/30
+ cmd: $NMCLI -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -1553,6 +1564,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4236,7 +4248,7 @@ connection.type:
+ connection.interface-name:              --
+ 
+ <<<
+-size: 5724
++size: 5777
+ location: src/tests/client/test-client.py:test_004()/75
+ cmd: $NMCLI --color yes con s con-vpn-1
+ lang: C
+@@ -4251,6 +4263,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4361,7 +4374,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5761
++size: 5814
+ location: src/tests/client/test-client.py:test_004()/76
+ cmd: $NMCLI --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -4376,6 +4389,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4486,7 +4500,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5724
++size: 5777
+ location: src/tests/client/test-client.py:test_004()/77
+ cmd: $NMCLI --color yes con s con-vpn-1
+ lang: C
+@@ -4501,6 +4515,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4611,7 +4626,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5761
++size: 5814
+ location: src/tests/client/test-client.py:test_004()/78
+ cmd: $NMCLI --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -4626,6 +4641,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4736,7 +4752,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 4597
++size: 4650
+ location: src/tests/client/test-client.py:test_004()/79
+ cmd: $NMCLI --color yes -f ALL con s con-vpn-1
+ lang: C
+@@ -4751,6 +4767,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -4840,7 +4857,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 4624
++size: 4677
+ location: src/tests/client/test-client.py:test_004()/80
+ cmd: $NMCLI --color yes -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -4855,6 +4872,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -7538,7 +7556,7 @@ connection.type:
+ connection.interface-name:              --
+ 
+ <<<
+-size: 6733
++size: 6786
+ location: src/tests/client/test-client.py:test_004()/125
+ cmd: $NMCLI --pretty con s con-vpn-1
+ lang: C
+@@ -7556,6 +7574,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -7676,7 +7695,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6783
++size: 6836
+ location: src/tests/client/test-client.py:test_004()/126
+ cmd: $NMCLI --pretty con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -7694,6 +7713,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -7814,7 +7834,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6733
++size: 6786
+ location: src/tests/client/test-client.py:test_004()/127
+ cmd: $NMCLI --pretty con s con-vpn-1
+ lang: C
+@@ -7832,6 +7852,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -7952,7 +7973,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6783
++size: 6836
+ location: src/tests/client/test-client.py:test_004()/128
+ cmd: $NMCLI --pretty con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -7970,6 +7991,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -8090,7 +8112,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 5214
++size: 5267
+ location: src/tests/client/test-client.py:test_004()/129
+ cmd: $NMCLI --pretty -f ALL con s con-vpn-1
+ lang: C
+@@ -8108,6 +8130,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -8202,7 +8225,7 @@ proxy.pac-script:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 5246
++size: 5299
+ location: src/tests/client/test-client.py:test_004()/130
+ cmd: $NMCLI --pretty -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -8220,6 +8243,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -11512,7 +11536,7 @@ connection.interface-name:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6745
++size: 6798
+ location: src/tests/client/test-client.py:test_004()/175
+ cmd: $NMCLI --pretty --color yes con s con-vpn-1
+ lang: C
+@@ -11530,6 +11554,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -11650,7 +11675,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6795
++size: 6848
+ location: src/tests/client/test-client.py:test_004()/176
+ cmd: $NMCLI --pretty --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -11668,6 +11693,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -11788,7 +11814,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6745
++size: 6798
+ location: src/tests/client/test-client.py:test_004()/177
+ cmd: $NMCLI --pretty --color yes con s con-vpn-1
+ lang: C
+@@ -11806,6 +11832,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -11926,7 +11953,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6795
++size: 6848
+ location: src/tests/client/test-client.py:test_004()/178
+ cmd: $NMCLI --pretty --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -11944,6 +11971,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -12064,7 +12092,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 5226
++size: 5279
+ location: src/tests/client/test-client.py:test_004()/179
+ cmd: $NMCLI --pretty --color yes -f ALL con s con-vpn-1
+ lang: C
+@@ -12082,6 +12110,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -12176,7 +12205,7 @@ proxy.pac-script:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 5258
++size: 5311
+ location: src/tests/client/test-client.py:test_004()/180
+ cmd: $NMCLI --pretty --color yes -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -12194,6 +12223,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -15486,7 +15516,7 @@ connection.interface-name:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 2871
++size: 2924
+ location: src/tests/client/test-client.py:test_004()/225
+ cmd: $NMCLI --terse con s con-vpn-1
+ lang: C
+@@ -15501,6 +15531,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -15611,7 +15642,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2881
++size: 2934
+ location: src/tests/client/test-client.py:test_004()/226
+ cmd: $NMCLI --terse con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -15626,6 +15657,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -15736,7 +15768,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2871
++size: 2924
+ location: src/tests/client/test-client.py:test_004()/227
+ cmd: $NMCLI --terse con s con-vpn-1
+ lang: C
+@@ -15751,6 +15783,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -15861,7 +15894,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2881
++size: 2934
+ location: src/tests/client/test-client.py:test_004()/228
+ cmd: $NMCLI --terse con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -15876,6 +15909,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -15986,7 +16020,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2296
++size: 2349
+ location: src/tests/client/test-client.py:test_004()/229
+ cmd: $NMCLI --terse -f ALL con s con-vpn-1
+ lang: C
+@@ -16001,6 +16035,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -16090,7 +16125,7 @@ proxy.pac-url:
+ proxy.pac-script:
+ 
+ <<<
+-size: 2306
++size: 2359
+ location: src/tests/client/test-client.py:test_004()/230
+ cmd: $NMCLI --terse -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -16105,6 +16140,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -18758,7 +18794,7 @@ connection.type:802-11-wireless
+ connection.interface-name:
+ 
+ <<<
+-size: 2883
++size: 2936
+ location: src/tests/client/test-client.py:test_004()/275
+ cmd: $NMCLI --terse --color yes con s con-vpn-1
+ lang: C
+@@ -18773,6 +18809,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -18883,7 +18920,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2893
++size: 2946
+ location: src/tests/client/test-client.py:test_004()/276
+ cmd: $NMCLI --terse --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -18898,6 +18935,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -19008,7 +19046,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2883
++size: 2936
+ location: src/tests/client/test-client.py:test_004()/277
+ cmd: $NMCLI --terse --color yes con s con-vpn-1
+ lang: C
+@@ -19023,6 +19061,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -19133,7 +19172,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2893
++size: 2946
+ location: src/tests/client/test-client.py:test_004()/278
+ cmd: $NMCLI --terse --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -19148,6 +19187,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -19258,7 +19298,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2308
++size: 2361
+ location: src/tests/client/test-client.py:test_004()/279
+ cmd: $NMCLI --terse --color yes -f ALL con s con-vpn-1
+ lang: C
+@@ -19273,6 +19313,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -19362,7 +19403,7 @@ proxy.pac-url:
+ proxy.pac-script:
+ 
+ <<<
+-size: 2318
++size: 2371
+ location: src/tests/client/test-client.py:test_004()/280
+ cmd: $NMCLI --terse --color yes -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -19377,6 +19418,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -31830,7 +31872,7 @@ UUID-con-xx1-REPLACED-REPLACED-REPLA
+ 
+ 
+ <<<
+-size: 5730
++size: 5783
+ location: src/tests/client/test-client.py:test_004()/625
+ cmd: $NMCLI --mode multiline con s con-vpn-1
+ lang: C
+@@ -31845,6 +31887,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -31955,7 +31998,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5767
++size: 5820
+ location: src/tests/client/test-client.py:test_004()/626
+ cmd: $NMCLI --mode multiline con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -31970,6 +32013,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -32080,7 +32124,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5730
++size: 5783
+ location: src/tests/client/test-client.py:test_004()/627
+ cmd: $NMCLI --mode multiline con s con-vpn-1
+ lang: C
+@@ -32095,6 +32139,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -32205,7 +32250,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5767
++size: 5820
+ location: src/tests/client/test-client.py:test_004()/628
+ cmd: $NMCLI --mode multiline con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -32220,6 +32265,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -32330,7 +32376,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 4603
++size: 4656
+ location: src/tests/client/test-client.py:test_004()/629
+ cmd: $NMCLI --mode multiline -f ALL con s con-vpn-1
+ lang: C
+@@ -32345,6 +32391,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -32434,7 +32481,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 4630
++size: 4683
+ location: src/tests/client/test-client.py:test_004()/630
+ cmd: $NMCLI --mode multiline -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -32449,6 +32496,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -35632,7 +35680,7 @@ connection.type:
+ connection.interface-name:              --
+ 
+ <<<
+-size: 5742
++size: 5795
+ location: src/tests/client/test-client.py:test_004()/675
+ cmd: $NMCLI --mode multiline --color yes con s con-vpn-1
+ lang: C
+@@ -35647,6 +35695,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -35757,7 +35806,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5779
++size: 5832
+ location: src/tests/client/test-client.py:test_004()/676
+ cmd: $NMCLI --mode multiline --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -35772,6 +35821,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -35882,7 +35932,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5742
++size: 5795
+ location: src/tests/client/test-client.py:test_004()/677
+ cmd: $NMCLI --mode multiline --color yes con s con-vpn-1
+ lang: C
+@@ -35897,6 +35947,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -36007,7 +36058,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 5779
++size: 5832
+ location: src/tests/client/test-client.py:test_004()/678
+ cmd: $NMCLI --mode multiline --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -36022,6 +36073,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -36132,7 +36184,7 @@ VPN.CFG[2]:
+ VPN.CFG[3]:                             key3 = val3
+ 
+ <<<
+-size: 4615
++size: 4668
+ location: src/tests/client/test-client.py:test_004()/679
+ cmd: $NMCLI --mode multiline --color yes -f ALL con s con-vpn-1
+ lang: C
+@@ -36147,6 +36199,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -36236,7 +36289,7 @@ proxy.pac-url:
+ proxy.pac-script:                       --
+ 
+ <<<
+-size: 4642
++size: 4695
+ location: src/tests/client/test-client.py:test_004()/680
+ cmd: $NMCLI --mode multiline --color yes -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -36251,6 +36304,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -39434,7 +39488,7 @@ connection.type:
+ connection.interface-name:              --
+ 
+ <<<
+-size: 6750
++size: 6803
+ location: src/tests/client/test-client.py:test_004()/725
+ cmd: $NMCLI --mode multiline --pretty con s con-vpn-1
+ lang: C
+@@ -39452,6 +39506,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -39572,7 +39627,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6800
++size: 6853
+ location: src/tests/client/test-client.py:test_004()/726
+ cmd: $NMCLI --mode multiline --pretty con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -39590,6 +39645,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -39710,7 +39766,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6750
++size: 6803
+ location: src/tests/client/test-client.py:test_004()/727
+ cmd: $NMCLI --mode multiline --pretty con s con-vpn-1
+ lang: C
+@@ -39728,6 +39784,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -39848,7 +39905,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6800
++size: 6853
+ location: src/tests/client/test-client.py:test_004()/728
+ cmd: $NMCLI --mode multiline --pretty con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -39866,6 +39923,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -39986,7 +40044,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 5231
++size: 5284
+ location: src/tests/client/test-client.py:test_004()/729
+ cmd: $NMCLI --mode multiline --pretty -f ALL con s con-vpn-1
+ lang: C
+@@ -40004,6 +40062,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -40098,7 +40157,7 @@ proxy.pac-script:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 5263
++size: 5316
+ location: src/tests/client/test-client.py:test_004()/730
+ cmd: $NMCLI --mode multiline --pretty -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -40116,6 +40175,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -43938,7 +43998,7 @@ connection.interface-name:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6762
++size: 6815
+ location: src/tests/client/test-client.py:test_004()/775
+ cmd: $NMCLI --mode multiline --pretty --color yes con s con-vpn-1
+ lang: C
+@@ -43956,6 +44016,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -44076,7 +44137,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6812
++size: 6865
+ location: src/tests/client/test-client.py:test_004()/776
+ cmd: $NMCLI --mode multiline --pretty --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -44094,6 +44155,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -44214,7 +44276,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6762
++size: 6815
+ location: src/tests/client/test-client.py:test_004()/777
+ cmd: $NMCLI --mode multiline --pretty --color yes con s con-vpn-1
+ lang: C
+@@ -44232,6 +44294,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -44352,7 +44415,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 6812
++size: 6865
+ location: src/tests/client/test-client.py:test_004()/778
+ cmd: $NMCLI --mode multiline --pretty --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -44370,6 +44433,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -44490,7 +44554,7 @@ VPN.CFG[3]:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 5243
++size: 5296
+ location: src/tests/client/test-client.py:test_004()/779
+ cmd: $NMCLI --mode multiline --pretty --color yes -f ALL con s con-vpn-1
+ lang: C
+@@ -44508,6 +44572,7 @@ connection.interface-name:
+ connection.autoconnect:                 yes
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -44602,7 +44667,7 @@ proxy.pac-script:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 5275
++size: 5328
+ location: src/tests/client/test-client.py:test_004()/780
+ cmd: $NMCLI --mode multiline --pretty --color yes -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -44620,6 +44685,7 @@ connection.interface-name:
+ connection.autoconnect:                 tak
+ connection.autoconnect-priority:        0
+ connection.autoconnect-retries:         -1 (default)
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:               0 (default)
+ connection.auth-retries:                -1
+ connection.timestamp:                   0
+@@ -48442,7 +48508,7 @@ connection.interface-name:
+ -------------------------------------------------------------------------------
+ 
+ <<<
+-size: 2888
++size: 2941
+ location: src/tests/client/test-client.py:test_004()/825
+ cmd: $NMCLI --mode multiline --terse con s con-vpn-1
+ lang: C
+@@ -48457,6 +48523,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -48567,7 +48634,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2898
++size: 2951
+ location: src/tests/client/test-client.py:test_004()/826
+ cmd: $NMCLI --mode multiline --terse con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -48582,6 +48649,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -48692,7 +48760,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2888
++size: 2941
+ location: src/tests/client/test-client.py:test_004()/827
+ cmd: $NMCLI --mode multiline --terse con s con-vpn-1
+ lang: C
+@@ -48707,6 +48775,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -48817,7 +48886,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2898
++size: 2951
+ location: src/tests/client/test-client.py:test_004()/828
+ cmd: $NMCLI --mode multiline --terse con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -48832,6 +48901,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -48942,7 +49012,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2313
++size: 2366
+ location: src/tests/client/test-client.py:test_004()/829
+ cmd: $NMCLI --mode multiline --terse -f ALL con s con-vpn-1
+ lang: C
+@@ -48957,6 +49027,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -49046,7 +49117,7 @@ proxy.pac-url:
+ proxy.pac-script:
+ 
+ <<<
+-size: 2323
++size: 2376
+ location: src/tests/client/test-client.py:test_004()/830
+ cmd: $NMCLI --mode multiline --terse -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -49061,6 +49132,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -52244,7 +52316,7 @@ connection.type:802-11-wireless
+ connection.interface-name:
+ 
+ <<<
+-size: 2900
++size: 2953
+ location: src/tests/client/test-client.py:test_004()/875
+ cmd: $NMCLI --mode multiline --terse --color yes con s con-vpn-1
+ lang: C
+@@ -52259,6 +52331,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -52369,7 +52442,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2910
++size: 2963
+ location: src/tests/client/test-client.py:test_004()/876
+ cmd: $NMCLI --mode multiline --terse --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -52384,6 +52457,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -52494,7 +52568,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2900
++size: 2953
+ location: src/tests/client/test-client.py:test_004()/877
+ cmd: $NMCLI --mode multiline --terse --color yes con s con-vpn-1
+ lang: C
+@@ -52509,6 +52583,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -52619,7 +52694,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2910
++size: 2963
+ location: src/tests/client/test-client.py:test_004()/878
+ cmd: $NMCLI --mode multiline --terse --color yes con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -52634,6 +52709,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -52744,7 +52820,7 @@ VPN.CFG[2]:key2 = val2
+ VPN.CFG[3]:key3 = val3
+ 
+ <<<
+-size: 2325
++size: 2378
+ location: src/tests/client/test-client.py:test_004()/879
+ cmd: $NMCLI --mode multiline --terse --color yes -f ALL con s con-vpn-1
+ lang: C
+@@ -52759,6 +52835,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+@@ -52848,7 +52925,7 @@ proxy.pac-url:
+ proxy.pac-script:
+ 
+ <<<
+-size: 2335
++size: 2388
+ location: src/tests/client/test-client.py:test_004()/880
+ cmd: $NMCLI --mode multiline --terse --color yes -f ALL con s con-vpn-1
+ lang: pl_PL.UTF-8
+@@ -52863,6 +52940,7 @@ connection.interface-name:
+ connection.autoconnect:yes
+ connection.autoconnect-priority:0
+ connection.autoconnect-retries:-1
++connection.autoconnect-reset-retries:   -1 (default)
+ connection.multi-connect:0
+ connection.auth-retries:-1
+ connection.timestamp:0
+Index: network-manager/src/tests/client/test-client.py
+===================================================================
+--- network-manager.orig/src/tests/client/test-client.py
++++ network-manager/src/tests/client/test-client.py
+@@ -1076,6 +1076,9 @@ class NMTestContext:
+         self.ctx_results = []
+         self.srv = None
+ 
++    def fail(self, msg=None):
++        raise self.parent_test.failureException(msg)
++
+     def calling_num(self, calling_fcn):
+         calling_num = self._calling_num.get(calling_fcn, 0) + 1
+         self._calling_num[calling_fcn] = calling_num
+@@ -1250,6 +1253,7 @@ class TestNmcli(unittest.TestCase):
+         Util.skip_without_dbus_session()
+         Util.skip_without_NM()
+         self.ctx = NMTestContext(self._testMethodName)
++        self.ctx.parent_test = self
+ 
+     def call_nmcli_l(
+         self,
+@@ -2278,6 +2282,7 @@ class TestNmCloudSetup(unittest.TestCase
+         Util.skip_without_dbus_session()
+         Util.skip_without_NM()
+         self.ctx = NMTestContext(self._testMethodName)
++        self.ctx.parent_test = self
+ 
+     _mac1 = "cc:00:00:00:00:01"
+     _mac2 = "cc:00:00:00:00:02"

--- a/debian/patches/uniontech005-hotspot-retry-when-failure.patch
+++ b/debian/patches/uniontech005-hotspot-retry-when-failure.patch
@@ -1,0 +1,146 @@
+Index: network-manager/src/core/devices/wifi/nm-device-wifi.c
+===================================================================
+--- network-manager.orig/src/core/devices/wifi/nm-device-wifi.c
++++ network-manager/src/core/devices/wifi/nm-device-wifi.c
+@@ -56,6 +56,8 @@
+ #define SCAN_REQUEST_SSIDS_MAX_NUM      32u
+ #define SCAN_REQUEST_SSIDS_MAX_AGE_MSEC (3 * 60 * NM_UTILS_MSEC_PER_SEC)
+ 
++#define HOTSPOT_FREQ_RETRY_MAX         4
++
+ #define _LOGT_scan(...) _LOGT(LOGD_WIFI_SCAN, "wifi-scan: " __VA_ARGS__)
+ 
+ /*****************************************************************************/
+@@ -128,6 +130,10 @@ typedef struct {
+ 
+     guint8 scan_periodic_interval_sec;
+ 
++    int hotspot_retry_count;
++    guint32 hotspot_failed_freqs[16];
++    guint hotspot_failed_freqs_num;
++
+     bool enabled : 1; /* rfkilled or not */
+     bool scan_is_scanning : 1;
+     bool scan_periodic_allowed : 1;
+@@ -2874,7 +2880,37 @@ supplicant_connection_timeout_cb(gpointe
+         /* In Ad-Hoc and AP modes there's nothing to check the encryption key
+          * (if any), so supplicant timeouts here are almost certainly the wifi
+          * driver being really stupid.
++         *
++         * For Hotspot/AP mode, retry with a different frequency before giving
++         * up. The driver may fail to initialize AP mode on some channels due to
++         * regulatory restrictions or hardware issues.
+          */
++        if (priv->mode == _NM_802_11_MODE_AP && priv->hotspot_retry_count < HOTSPOT_FREQ_RETRY_MAX) {
++            NMWifiAP *ap = priv->current_ap;
++            guint32   failed_freq = ap ? nm_wifi_ap_get_freq(ap) : 0;
++
++            /* Record the failed frequency so ensure_hotspot_frequency() skips it. */
++            if (failed_freq > 0
++                && priv->hotspot_failed_freqs_num < G_N_ELEMENTS(priv->hotspot_failed_freqs)) {
++                priv->hotspot_failed_freqs[priv->hotspot_failed_freqs_num++] = failed_freq;
++            }
++
++            priv->hotspot_retry_count++;
++
++            _LOGI(LOGD_DEVICE | LOGD_WIFI,
++                  "Activation: (wifi) Hotspot network creation took too long on freq %u, "
++                  "retrying with a different frequency (attempt %d/%d)",
++                  failed_freq, priv->hotspot_retry_count, HOTSPOT_FREQ_RETRY_MAX);
++
++            /* Clear the frequency on the AP so ensure_hotspot_frequency() picks a new one. */
++            if (ap)
++                nm_wifi_ap_set_freq(ap, 0);
++
++            /* Reschedule from stage1 to re-enter act_stage2_config with a new frequency. */
++            nm_device_activate_schedule_stage1_device_prepare(device, FALSE);
++            return FALSE;
++        }
++
+         _LOGW(LOGD_DEVICE | LOGD_WIFI,
+               "Activation: (wifi) %s network creation took too long, failing activation",
+               priv->mode == _NM_802_11_MODE_ADHOC ? "Ad-Hoc" : "Hotspot");
+@@ -3125,6 +3161,13 @@ act_stage1_prepare(NMDevice *device, NMD
+     else if (g_strcmp0(mode, NM_SETTING_WIRELESS_MODE_AP) == 0) {
+         priv->mode = _NM_802_11_MODE_AP;
+ 
++        /* Reset hotspot frequency retry state for a new activation attempt.
++         * Don't reset during a retry cycle (hotspot_retry_count > 0), where
++         * act_stage1_prepare is re-entered via
++         * nm_device_activate_schedule_stage1_device_prepare(). */
++        if (priv->hotspot_retry_count == 0)
++            priv->hotspot_failed_freqs_num = 0;
++
+         /* Scanning not done in AP mode; clear the scan list */
+         remove_all_aps(self);
+     } else if (g_strcmp0(mode, NM_SETTING_WIRELESS_MODE_MESH) == 0)
+@@ -3179,6 +3222,7 @@ act_stage1_prepare(NMDevice *device, NMD
+ static void
+ ensure_hotspot_frequency(NMDeviceWifi *self, NMSettingWireless *s_wifi, NMWifiAP *ap)
+ {
++	NMDeviceWifiPrivate *priv = NM_DEVICE_WIFI_GET_PRIVATE(self);
+     guint32     a_freqs[]  = {5180, 5200, 5220, 5745, 5765, 5785, 5805, 0};
+     guint32     bg_freqs[] = {2412, 2437, 2462, 2472, 0};
+     guint32    *rnd_freqs;
+@@ -3188,6 +3232,7 @@ ensure_hotspot_frequency(NMDeviceWifi *s
+     guint32     freq;
+     guint64     rnd;
+     guint       i;
++    guint		j;
+     guint       l;
+ 
+     nm_assert(ap);
+@@ -3241,6 +3286,30 @@ ensure_hotspot_frequency(NMDeviceWifi *s
+         NM_SWAP(&rnd_freqs[i], &rnd_freqs[i + (rnd % l)]);
+     }
+ 
++    /* Skip frequencies that failed in previous hotspot attempts. */
++    if (priv->hotspot_failed_freqs_num > 0) {
++        l = 0;
++        for (i = 0; i < rnd_freqs_len; i++) {
++            gboolean skip = FALSE;
++            for (j = 0; j < priv->hotspot_failed_freqs_num; j++) {
++                if (rnd_freqs[i] == priv->hotspot_failed_freqs[j]) {
++                    skip = TRUE;
++                    break;
++                }
++            }
++            if (!skip)
++                rnd_freqs[l++] = rnd_freqs[i];
++        }
++        rnd_freqs[l] = 0;
++        rnd_freqs_len = l;
++        if (rnd_freqs_len == 0) {
++            _LOGW(LOGD_WIFI,
++                  "hotspot: all %u candidate frequencies have been tried and failed",
++                  priv->hotspot_failed_freqs_num);
++            return;
++        }
++    }
++
+     freq = nm_platform_wifi_find_frequency(nm_device_get_platform(device),
+                                            nm_device_get_ifindex(device),
+                                            rnd_freqs,
+@@ -3248,7 +3317,12 @@ ensure_hotspot_frequency(NMDeviceWifi *s
+     if (freq == 0)
+         freq = rnd_freqs[0];
+ 
+-    _LOGD(LOGD_WIFI, "set frequency for hotspot AP to %u", freq);
++    if (priv->hotspot_retry_count > 0)
++        _LOGI(LOGD_WIFI,
++              "hotspot: retry %d, trying frequency %u",
++              priv->hotspot_retry_count, freq);
++    else
++        _LOGD(LOGD_WIFI, "set frequency for hotspot AP to %u", freq);
+ 
+     if (nm_wifi_ap_set_freq(ap, freq))
+         _ap_dump(self, LOGL_DEBUG, ap, "updated", 0);
+@@ -3567,6 +3641,8 @@ device_state_changed(NMDevice
+         _indicate_addressing_running_reset(self);
+         break;
+     case NM_DEVICE_STATE_DISCONNECTED:
++        priv->hotspot_retry_count      = 0;
++        priv->hotspot_failed_freqs_num = 0;
+         break;
+     default:
+         break;

--- a/debian/rules
+++ b/debian/rules
@@ -69,3 +69,6 @@ override_dh_installsystemd:
 
 override_dh_ppp:
 	dh_ppp --breaks
+
+override_dh_auto_test:
+	NM_TEST_REGENERATE=1 dh_auto_test


### PR DESCRIPTION
When creating a WiFi hotspot with auto channel selection (channel=0),the supplicant may time out on certain frequencies due to driver issues or regulatory restrictions. Instead of failing immediately, retry with a different frequency up to 4 times before giving up.

The failed frequency is recorded and skipped in subsequent attempts,so each retry tries a genuinely different channel.

修复WiFi热点在自动选信道时因驱动或法规限制导致超时的问题。
当热点创建超时时不立即失败，而是依次尝试不同频率，最多重试4次。
每次超时的频率会被记录并在后续重试中跳过，确保每次都尝试真正不同的信道。

PMS: BUG-353699